### PR TITLE
Prevent OverCounting on Serial Tx full

### DIFF
--- a/usb_serial_print_speed.ino
+++ b/usb_serial_print_speed.ino
@@ -39,7 +39,8 @@ void loop() {
   Serial.print(count);
   Serial.print(", lines/sec=");
   Serial.println(count_per_second);
-  count = count + 1;
+  if ( Serial.availableForWrite() > 15 ) // skip count inc 
+    count = count + 1;
   uint32_t msec = millis();
   if (msec - prior_msec > 1000) {
     // when 1 second as elapsed, update the lines/sec count


### PR DESCRIPTION
RE post #2647: https://forum.pjrc.com/threads/54711-Teensy-4-0-First-Beta-Test?p=204724&viewfull=1#post204724
Paul said: "I don't understand this. For 12 Mbit/sec USB, 36848 lines/sec should be the theoretical maximum. "

This change stops overcounting when Serial transmit is full and non-blocking Teensy keeps loop() running at full speed when no lines are printed.

Not sure of the value of "15" and 'available' function has to be supported: if ( Serial.availableForWrite() > 15 ) // skip count inc 

See post #2674 : https://forum.pjrc.com/threads/54711-Teensy-4-0-First-Beta-Test?p=204762&viewfull=1#post204762